### PR TITLE
feat: add testing and standalone mode

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team leader @vsoch. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/.github/dev-requirements.txt
+++ b/.github/dev-requirements.txt
@@ -1,0 +1,4 @@
+pre-commit
+black==23.3.0
+isort
+flake8

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: []
+
+jobs:
+  test:
+    name: Test Flux Compspec
+    runs-on: ubuntu-latest
+    container:
+      image: fluxrm/flux-sched:jammy
+      options: --user root
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Dependencies
+        run: apt-get update && apt-get install -y python3-pip
+      - name: Install compspec
+        run: python3 -m pip install compspec
+      - name: Install compspec-ior
+        run: python3 -m pip install .
+      - name: Test extracting data
+        run: flux start --test-size=4 compspec extract flux
+      - name: Test Python Standalone
+        run: flux start --test-size=4 python3 ./examples/singleton-run.py
+
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup black linter
+      run: conda create --quiet --name black pyflakes
+
+    - name: Check Spelling
+      uses: crate-ci/typos@7ad296c72fa8265059cc03d1eda562fbdfcd6df2 # v1.9.0
+      with:
+        files: ./README.md
+
+    - name: Lint and format Python code
+      run: |
+        export PATH="/usr/share/miniconda/bin:$PATH"
+        source activate black
+        pip install -r .github/dev-requirements.txt
+        pre-commit run --all-files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/compspec/compspec-flux/tree/main) (0.0.x)
- - Initial creation of project skeleton (0.0.0)
+ - support for standalone mode and basic test CI (0.0.11)
+ - Initial creation of project skeleton (0.0.1)

--- a/README.md
+++ b/README.md
@@ -42,37 +42,61 @@ compspec extract flux
 
 ```console
 {
-    "0": {
-        "id": 0,
-        "metadata": {
-            "type": "cluster",
-            "basename": "cluster",
-            "name": "cluster0",
-            "uniq_id": 0,
-            "containment": {
-                "paths": "/cluster0"
+    "graph": {
+        "nodes": {
+            "0": {
+                "id": 0,
+                "metadata": {
+                    "type": "cluster",
+                    "basename": "cluster",
+                    "name": "cluster0",
+                    "uniq_id": 0,
+                    "containment": {
+                        "paths": "/cluster0"
+                    },
+                    "size": 1,
+                    "unit": "",
+                    "rank": 0,
+                    "exclusive": false
+                }
             },
-            "size": 1,
-            "unit": "",
-            "rank": 0,
-            "exclusive": false
-        }
-    },
-    "1": {
-        "id": 1,
-        "metadata": {
-            "type": "node",
-            "basename": "node",
-            "name": "node1",
-            "uniq_id": 1,
-            "containment": {
-                "paths": "/cluster0/node1"
+            "1": {
+                "id": 1,
+                "metadata": {
+                    "type": "node",
+                    "basename": "node",
+                    "name": "node1",
+                    "uniq_id": 1,
+                    "containment": {
+                        "paths": "/cluster0/node1"
+                    },
+                    "size": 1,
+                    "unit": "",
+                    "rank": 0,
+                    "exclusive": false
+                }
+            }
+        },
+        "edges": [
+            {
+                "source": "0",
+                "target": "1",
+                "metadata": {
+                    "name": {
+                        "containment": "contains"
+                    }
+                }
             },
-            "size": 1,
-            "unit": "",
-            "rank": 0,
-            "exclusive": false
-        }
+            {
+                "source": "1",
+                "target": "0",
+                "metadata": {
+                    "name": {
+                        "containment": "in"
+                    }
+                }
+            }
+        ]
     }
 }
 ```
@@ -84,7 +108,6 @@ And how to save to file
 ```bash
 compspec extract --outfile cluster-resources.json flux
 ```
-
 
 ## License
 

--- a/compspec_flux/plugin.py
+++ b/compspec_flux/plugin.py
@@ -72,9 +72,31 @@ class Plugin(PluginBase):
             help="Node exclusive status, if derived from RPC",
         )
 
-    def extract(self, args, extra):
+    def graph_from_rpc(self, rpc=None, jgf_v1=False):
         """
-        Use Python flux bindings to save resource graph.
+        Given a graph in the rpc response, return as is or converted to v2
+        """
+        # If running the function standalone, get it here.
+        if not rpc:
+            rpc = self.get_rpc()
+
+        # In case there is other stuff alongside graph, prune it out
+        graph = {"graph": rpc["all"]["graph"]}
+
+        # If we want version 1, return as is if args.jgf_v1
+        if jgf_v1:
+            return graph
+
+        # Otherwise convert to version 2
+        nodes = {}
+        for node in graph.get("nodes", []):
+            nodes[node[id]] = node
+        graph["nodes"] = nodes
+        return graph
+
+    def get_rpc(self):
+        """
+        Helper function to use a flux handle to generate the rpc
         """
         try:
             import flux
@@ -84,82 +106,94 @@ class Plugin(PluginBase):
             handle = flux.Flux()
         except Exception:
             raise ValueError("Please run this plugin from inside of a Flux instance.")
+        return handle.rpc("sched.resource-status").get()
 
+    def generate_graph(self, cluster_name="cluster", exclusive=False, jgf_v1=False):
+        """
+        Generate graph is explicitly for an out of tree use case
+        (e.g., a user wanting a graph for their flux instance)
+        """
         # Note: this is showing up as an RPC and not a graph, but likely
         # there are other cases when it could be a graph (that we should check for)
-        rpc = handle.rpc("sched.resource-status").get()
+        rpc = self.get_rpc()
 
         # Case 1: the rpc returns a full graph
         # Assume this can happen in some cases (although I have not reproduced)
         if "all" in rpc and "graph" in rpc["all"]:
-            # In case there is other stuff alongside graph, prune it out
-            graph = {"graph": rpc["all"]["graph"]}
-
-            # If we want version 1, return as is if args.jgf_v1
-            if args.jgf_v1:
-                return graph
-
-            # Otherwise convert to version 2
-            nodes = {}
-            for node in graph.get("nodes", []):
-                nodes[node[id]] = node
-            graph["nodes"] = nodes
-            return graph
-
-        # Return the raw rpc if it doesn't fit the pattern below
-        graph = rpc
+            return self.graph_from_rpc(rpc, jgf_v1)
 
         # This is the output I'm seeing with flux-sched jammy container
         # In this case, extend out to rpc
         if "all" in rpc and "down" in rpc and "allocated" in rpc:
-            nodelist = rpc.get("all", {}).get("execution", {}).get("nodelist")
+            return self.convert_rpc_to_graph(rpc, cluster_name, exclusive)
 
-            # If we don't have a nodelist, abandon ship
-            if not nodelist:
-                return graph
+        # Return the raw rpc if it doesn't fit the pattern below
+        return rpc
 
-            # Assume all node are connected to the cluster root, and that's it
-            edges = []
+    def convert_rpc_to_graph(self, rpc=None, cluster_name="cluster", exclusive=False):
+        """
+        Given a traditional (shortened) RPC response, convert to a simple graph.
 
-            # Add the hostnames as nodes. We don't know about other resources from this
-            # at least from what I can see
-            nodes = {}
-            nodes["0"] = generate_root(args.flux_cluster, args.flux_exclusive)
-            uid = 1
-            nodelist = parse_nodelist(nodelist)
-            for i, hostname in enumerate(nodelist):
-                # idx 0 is the cluster
-                idx = i + 1
-                containment = {"paths": f"/{args.flux_cluster}0/node{idx}"}
-                metadata = {
-                    "type": "node",
-                    "basename": "node",
-                    "name": f"node{idx}",
-                    "uniq_id": uid,
-                    "containment": containment,
-                    "size": 1,
-                    "unit": "",
-                    "rank": 0,
-                    "exclusive": args.flux_exclusive,
+        This currently only handles simple designs, and can be extended if needed.
+        """
+        # If running the function standalone, get it here.
+        if not rpc:
+            rpc = self.get_rpc()
+
+        nodelist = rpc.get("all", {}).get("execution", {}).get("nodelist")
+
+        # If we don't have a nodelist, abandon ship
+        if not nodelist:
+            return rpc
+
+        # Assume all node are connected to the cluster root, and that's it
+        edges = []
+
+        # Add the hostnames as nodes. We don't know about other resources from this
+        # at least from what I can see
+        nodes = {}
+        nodes["0"] = generate_root(cluster_name, exclusive)
+        uid = 1
+        nodelist = parse_nodelist(nodelist)
+        for i, hostname in enumerate(nodelist):
+            # idx 0 is the cluster
+            idx = i + 1
+            containment = {"paths": f"/{cluster_name}0/node{idx}"}
+            metadata = {
+                "type": "node",
+                "basename": "node",
+                "name": f"node{idx}",
+                "uniq_id": uid,
+                "containment": containment,
+                "size": 1,
+                "unit": "",
+                "rank": 0,
+                "exclusive": exclusive,
+            }
+            nodes[str(idx)] = {"id": idx, "metadata": metadata}
+
+            # Now add an edge from cluster to node
+            edges.append(
+                {
+                    "source": "0",
+                    "target": str(idx),
+                    "metadata": {"name": {"containment": "contains"}},
                 }
-                nodes[str(idx)] = {"id": idx, "metadata": metadata}
+            )
+            edges.append(
+                {
+                    "source": str(idx),
+                    "target": "0",
+                    "metadata": {"name": {"containment": "in"}},
+                }
+            )
+            uid += 1
 
-                # Now add an edge from cluster to node
-                edges.append(
-                    {
-                        "source": "0",
-                        "target": str(idx),
-                        "metadata": {"name": {"containment": "contains"}},
-                    }
-                )
-                edges.append(
-                    {
-                        "source": str(idx),
-                        "target": "0",
-                        "metadata": {"name": {"containment": "in"}},
-                    }
-                )
-                uid += 1
-            graph = {"graph": {"nodes": nodes, "edges": edges}}
+        return {"graph": {"nodes": nodes, "edges": edges}}
 
-        return nodes
+    def extract(self, args, extra):
+        """
+        Use Python flux bindings to save resource graph.
+        """
+        # Unwrap needed arguments into user friendly function call
+        return self.generate_graph(args.flux_cluster, args.flux_exclusive, args.jgf_v1)

--- a/compspec_flux/version.py
+++ b/compspec_flux/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2024, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.0.1"
+__version__ = "0.0.11"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "compspec-flux"

--- a/examples/singleton-run.py
+++ b/examples/singleton-run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# This is a singleton example of running the plugin without compspec,
+# primarily to test, etc or just generate a node graph.
+
+import json
+
+from compspec_flux.plugin import Plugin
+
+
+def main():
+    # Load data we've generated with IOR
+    plugin = Plugin("flux")
+
+    # Generate the cluster graph
+    graph = plugin.generate_graph(cluster_name="dinosaur", exclusive=False)
+    print(json.dumps(graph, indent=4))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Problem: we should have a basic test that the plugin works with compspec.
Solution: add a test, along with refactoring the plugin organization so that it is possible to run a single function in a flux instance, "generate_cluster" that will dump out the node graph on the fly, and no need to be executed as an extraction plugin by the higher level compspec. I'm also adding:

- an example for the standalone use case
- a code of conduct
- a fixed README example (I was only showing the nodes, oups)